### PR TITLE
Replace promise check with Promise.resolve

### DIFF
--- a/src/race-until.js
+++ b/src/race-until.js
@@ -1,12 +1,3 @@
-function isPromise(obj) {
-  return (
-    !!obj &&
-    (typeof obj === 'object' || typeof obj === 'function') &&
-    typeof obj.then === 'function' &&
-    typeof obj.catch === 'function'
-  );
-}
-
 export function timebomb(timeout = 3000, timeoutResponse = 'Timeout') {
   return new Promise((resolve, reject) => {
     setTimeout(() => {
@@ -20,8 +11,5 @@ export function timebomb(timeout = 3000, timeoutResponse = 'Timeout') {
 }
 
 export function raceUntil(p, timeout = 3000, timeoutResponse = 'Timeout') {
-  if (!isPromise(p)) {
-    throw new Error('Missing promise option');
-  }
-  return Promise.race([p, timebomb(timeout, timeoutResponse)]);
+  return Promise.race([Promise.resolve(p), timebomb(timeout, timeoutResponse)]);
 }


### PR DESCRIPTION
`Promise.resolve` will always return a promise, so instead of checking for `p` to be a promise

See: https://stackoverflow.com/questions/27746304/how-do-i-tell-if-an-object-is-a-promise
Also: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#Methods
> Generally, if you don't know if a value is a promise or not, Promise.resolve(value) it instead and work with the return value as a promise.